### PR TITLE
Add video-demo collection import (2Gi)

### DIFF
--- a/kustomize/collection-import/collections.json
+++ b/kustomize/collection-import/collections.json
@@ -70,5 +70,6 @@
   "wbs" : "10Gi",
   "western-travels-photo-album" : "6Gi",
   "yearbooks" : "750Gi",
-  "zelma_long" : "75Gi"
+  "zelma_long" : "75Gi",
+  "video-demo" : "2Gi"
 }

--- a/kustomize/collection-import/overlays/video-demo/job.yaml
+++ b/kustomize/collection-import/overlays/video-demo/job.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: import-video-demo
+spec:
+  template:
+    spec:
+      containers:
+      - name: importer
+        env:
+          - name: COLLECTION_NAME
+            value: video-demo
+        volumeMounts:
+        - name: import-volume
+          mountPath: /data
+      volumes:
+      - name: import-volume
+        persistentVolumeClaim:
+          claimName: import-video-demo-volume-claim

--- a/kustomize/collection-import/overlays/video-demo/kustomization.yaml
+++ b/kustomize/collection-import/overlays/video-demo/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- volume.yaml
+- ../../base
+
+patches:
+  - path: job.yaml
+    target:
+      kind: Job
+      name: import
+    options:
+      allowNameChange: true

--- a/kustomize/collection-import/overlays/video-demo/volume.yaml
+++ b/kustomize/collection-import/overlays/video-demo/volume.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: import-video-demo-volume-claim
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: standard-rwo
+  resources:
+    requests:
+      storage: 2Gi


### PR DESCRIPTION
Adds the `video-demo` collection to the importable set — a demo collection for testing AV support (video playback, WebVTT captions, synced transcripts) on **dev**.

- Metadata repo: [`ucd-library/dams-video-demo-metadata`](https://github.com/ucd-library/dams-video-demo-metadata) (public, metadata-only)
- Binaries: `gs://dams-collections-binary-backups/video-demo/` (~1.5GB — two H.264 MP4s, WebVTT captions, transcript; already uploaded)
- Fake ARKs (`ark:/99999/fk4videodemo*`) — not for production promotion
- Unrelated to the `bekins` (D-809) collection

Generated with `generate.js`; `collections.json` change is one added line.

**After merge someone with `ucdlib-dams` access needs to run `cmds/sync-kustomize-gcs.sh`** so the gcs-sync sidecar picks up the new overlay — then the import can be triggered from the dev admin UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kxhK5EbRDhpnz8jL1BvTR